### PR TITLE
Re-exports

### DIFF
--- a/components/core/Effectful/Zoo/Concurrent.hs
+++ b/components/core/Effectful/Zoo/Concurrent.hs
@@ -1,0 +1,5 @@
+module Effectful.Zoo.Concurrent
+  ( module Effectful.Concurrent
+  ) where
+
+import Effectful.Concurrent

--- a/components/core/Effectful/Zoo/Concurrent/Async.hs
+++ b/components/core/Effectful/Zoo/Concurrent/Async.hs
@@ -1,0 +1,5 @@
+module Effectful.Zoo.Concurrent.Async
+  ( module Effectful.Concurrent.Async
+  ) where
+
+import Effectful.Concurrent.Async

--- a/components/core/Effectful/Zoo/Core.hs
+++ b/components/core/Effectful/Zoo/Core.hs
@@ -1,6 +1,9 @@
 module Effectful.Zoo.Core
   ( type (<:),
     type (<<:),
+
+    MonadIO(..),
   ) where
 
+import Effectful
 import Effectful.Zoo.Prim

--- a/effectful-zoo.cabal
+++ b/effectful-zoo.cabal
@@ -141,6 +141,8 @@ library core
                         yaml,
   visibility:           public
   exposed-modules:      Effectful.Zoo.Aeson
+                        Effectful.Zoo.Concurrent
+                        Effectful.Zoo.Concurrent.Async
                         Effectful.Zoo.Console.Data.Writer
                         Effectful.Zoo.Console.Dynamic
                         Effectful.Zoo.Console.Dynamic.Api


### PR DESCRIPTION
This way, users of the library will only need to import `Effectful` from the `effectful-core` library and then only import from `Effectful.Zoo.*`.